### PR TITLE
Add panHandlers to renderIndicator

### DIFF
--- a/src/VerticalSlider.tsx
+++ b/src/VerticalSlider.tsx
@@ -265,6 +265,7 @@ export default class VerticalSlider extends React.Component<props, state> {
                     backgroundColor: ballIndicatorColor,
                   },
             ]}
+            {...this.state.panResponder.panHandlers}
           >
             {renderIndicator ? (
               renderIndicator(value)


### PR DESCRIPTION
If you are using a large renderindicator, the pan events are not caught when over the indicator graphic. Adding them to the renderinciator as well fixes this.