### PR TITLE
fix: listen to state change and update slider display

### DIFF
--- a/src/VerticalSlider.tsx
+++ b/src/VerticalSlider.tsx
@@ -134,7 +134,7 @@ export default class VerticalSlider extends React.Component<props, state> {
     return ((value - min) * height) / (max - min);
   };
 
-  _changeState = (value: number): void => {
+  _changeSliderDisplay = (value: number): void => {
     const {
       height,
       ballIndicatorWidth = 48,
@@ -168,13 +168,24 @@ export default class VerticalSlider extends React.Component<props, state> {
         useNativeDriver: false,
       }),
     ]).start();
+  };
+
+  _changeState = (value: number): void => {
+    this._changeSliderDisplay(value);
     this.setState({ value });
   };
 
   componentDidMount() {
     const { value } = this.props;
-    if (value) {
+    if (value !== null && value !== undefined) {
       this._changeState(value);
+    }
+  }
+
+  componentDidUpdate() {
+    const { value } = this.props;
+    if (value !== null && value !== undefined) {
+      this._changeSliderDisplay(value);
     }
   }
 


### PR DESCRIPTION
- Listen to `value` state change and update the slider to the corresponding height. This will be useful when `value` is not changed by sliding (imagine this slider as a volume control, and there is a separate "mute" button, the slider should go to 0 when the mute button is tapped).

- Since `value` is a number and `0` is a valid value, use `if (value !== null && value !== undefined)` to do null check.