### PR TITLE
Force slider to rerender on props.value change

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -177,6 +177,13 @@ export default class VerticalSlider extends React.Component<props, state> {
       this._changeState(value);
     }
   }
+  
+  shouldComponentUpdate(nextProps: props, nextState: state){
+    if(nextProps.value && nextProps.value != nextState.value ){
+      this._changeState(nextProps.value);
+    }
+    return false
+  }
 
   render() {
     const {


### PR DESCRIPTION
Force updating slider value from outside the slider, the value now acts like default value, not state updated value, this will make it state updated 