### PR TITLE
fix: fire onChange function if called from outside the slider if the …

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -179,7 +179,7 @@ export default class VerticalSlider extends React.Component<props, state> {
   }
 
   shouldComponentUpdate(nextProps: props, nextState: state) {
-    if (nextProps.value && nextProps.value !== nextState.value) {
+    if (typeof nextProps.value === 'number' && nextProps.value !== nextState.value) {
       this._changeState(nextProps.value);
     }
     return false;


### PR DESCRIPTION
When calling `onChange` function with value zero without moving the slider.
The state will be updated but not the slider.